### PR TITLE
Fix Simplete reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "passport": "^0.3.2",
     "passport-http": "^0.3.0",
     "select2": "^4.0.2",
-    "simplete": "innoq/simplete#response_result_filter"
+    "simplete": "innoq/simplete.obsolete#response_result_filter"
   },
   "devDependencies": {
     "babel-core": "^6.5.2",


### PR DESCRIPTION
the original Simplete proof of concept now resides in a deprecated repo

Simplete has been rewritten from scratch and released as a proper
package: https://www.npmjs.com/package/simplete